### PR TITLE
chore: add test coverage using codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
       
       - name: Func Coverage
-        run: go tool func -html=coverage.out
+        run: go tool -func=coverage.out
       
       # See: https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-uploader
       - name: Codecov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
       
       - name: Func Coverage
-        run: go tool -func=coverage.out
+        run: go tool cover -func=coverage.out
       
       # See: https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-uploader
       - name: Codecov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Test
         run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
       
+      # See: https://go.dev/blog/cover
       - name: Func Coverage
         run: go tool cover -func=coverage.out
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ~1.17.5
+          go-version: ~1.17.8
       
       - name: Build
         run: go build ./...
@@ -35,14 +35,6 @@ jobs:
       - name: Func Coverage
         run: go tool cover -func=coverage.out
       
-      # See: https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-uploader
-      - name: Codecov
-        run: |
-          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-          gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-          shasum -a 256 -c codecov.SHA256SUM
-          chmod +x codecov
-          ./codecov
+      # See: https://about.codecov.io/blog/getting-started-with-code-coverage-for-golang/
+      - name: Upload Coverage to Codecov
+        run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,11 @@
+name: build
+
 on:
   push:
     branches:
       - main
   pull_request:
-name: build
+
 jobs:
   golangci:
     name: Build, Lint, Vet, Test
@@ -15,13 +17,32 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ~1.17.5
+      
       - name: Build
         run: go build ./...
+      
       - name: Vet
         run: go vet ./...
+      
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
           version: latest
+  
       - name: Test
-        run: go test -race ./...
+        run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
+      
+      - name: Func Coverage
+        run: go tool func -html=coverage.out
+      
+      # See: https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-uploader
+      - name: Codecov
+        run: |
+          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+          gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+          shasum -a 256 -c codecov.SHA256SUM
+          chmod +x codecov
+          ./codecov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # go
 
 ![build](https://github.com/colin-valentini/go/actions/workflows/build.yml/badge.svg?branch=main)
+[![codecov](https://codecov.io/gh/colin-valentini/go/branch/main/graph/badge.svg?token=EZ72S8AIU9)](https://codecov.io/gh/colin-valentini/go)
 
 This repository is a collection of Go practice problems, or other assorted findings.


### PR DESCRIPTION
Adds upload of test coverage reports to Codecov tooling following the setup instructions [here](https://about.codecov.io/blog/getting-started-with-code-coverage-for-golang/).