### PR TITLE
chore: upgrade to go 1.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ~1.17.8
+          go-version: ~1.18
       
       - name: Build
         run: go build ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/colin-valentini/go
 
-go 1.17
+go 1.18
 
 require github.com/stretchr/testify v1.7.0
 


### PR DESCRIPTION
Upgrades to Go version `1.18`