### PR TITLE
bazelify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,11 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Bazel files
+bazel-bazel-gazelle
+bazel-bin
+bazel-genfiles
+bazel-go
+bazel-out
+bazel-testlogs

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,14 @@
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+# gazelle:prefix github.com/colin-valentini/go
+gazelle(name = "gazelle")
+
+gazelle(
+    name = "gazelle-update-repos",
+    args = [
+        "-from_file=go.mod",
+        "-to_macro=deps.bzl%go_dependencies",
+        "-prune",
+    ],
+    command = "update-repos",
+)

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,25 @@
+.PHONY: build test fmt vet lint tidy fix-build
+
 build:
-	go build ./...
+	bazel build //...
 
 test:
-	go test -race ./...
+	bazel test --test_output=errors //...
 
 fmt:
 	gofmt -s -w .
 
 vet:
 	go vet ./...
+
+lint:
+	golangci-lint run ./...
+
+tidy:
+	go mod tidy -v
+
+update-bazel:
+	bazel run //:gazelle-update-repos
+	bazel run //:gazelle
+
+fix-build: fmt tidy update-bazel

--- a/README.md
+++ b/README.md
@@ -4,3 +4,11 @@
 [![codecov](https://codecov.io/gh/colin-valentini/go/branch/main/graph/badge.svg?token=EZ72S8AIU9)](https://codecov.io/gh/colin-valentini/go)
 
 This repository is a collection of Go practice problems, or other assorted findings.
+
+## prequisites
+
+Requires [golang](https://formulae.brew.sh/formula/go#default), [bazel](https://bazel.build/install/bazelisk), and [golangci-lint](https://golangci-lint.run/usage/install/#macos).
+
+## local development
+
+Run `make build` to build all of the things, and `make test` to test all of the things. If you get a bazel build error, try running `make fix-build` which will run formatting and build file updates. If you get a lint error, run `make lint` locally to execute the linter — see `.golangci.yml` for configuration, and https://golangci-lint.run/ for docs.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,42 @@
+workspace(name = "com_github_colin_valentini_go")
+
+# See https://github.com/bazelbuild/bazel-gazelle#setup
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+    ],
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+############################################################
+# Define your own dependencies here using go_repository.
+# Else, dependencies declared by rules_go/gazelle will be used.
+# The first declaration of an external repository "wins".
+############################################################
+
+load("//:deps.bzl", "go_dependencies")
+
+# gazelle:repository_macro deps.bzl%go_dependencies
+go_dependencies()
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.18")
+
+gazelle_dependencies()

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,0 +1,39 @@
+load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+def go_dependencies():
+    go_repository(
+        name = "com_github_davecgh_go_spew",
+        importpath = "github.com/davecgh/go-spew",
+        sum = "h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=",
+        version = "v1.1.0",
+    )
+    go_repository(
+        name = "com_github_pmezard_go_difflib",
+        importpath = "github.com/pmezard/go-difflib",
+        sum = "h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=",
+        version = "v1.0.0",
+    )
+    go_repository(
+        name = "com_github_stretchr_objx",
+        importpath = "github.com/stretchr/objx",
+        sum = "h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=",
+        version = "v0.1.0",
+    )
+    go_repository(
+        name = "com_github_stretchr_testify",
+        importpath = "github.com/stretchr/testify",
+        sum = "h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=",
+        version = "v1.7.0",
+    )
+    go_repository(
+        name = "in_gopkg_check_v1",
+        importpath = "gopkg.in/check.v1",
+        sum = "h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=",
+        version = "v0.0.0-20161208181325-20d25e280405",
+    )
+    go_repository(
+        name = "in_gopkg_yaml_v3",
+        importpath = "gopkg.in/yaml.v3",
+        sum = "h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=",
+        version = "v3.0.0-20200313102051-9f266ea9e77c",
+    )

--- a/practice/problems/leetcode/array/container-with-most-water/BUILD.bazel
+++ b/practice/problems/leetcode/array/container-with-most-water/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "container-with-most-water",
+    srcs = ["solution.go"],
+    importpath = "github.com/colin-valentini/go/practice/problems/leetcode/array/container-with-most-water",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "container-with-most-water_test",
+    srcs = ["solution_test.go"],
+    embed = [":container-with-most-water"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/practice/problems/leetcode/array/trapping-rain-water/BUILD.bazel
+++ b/practice/problems/leetcode/array/trapping-rain-water/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "trapping-rain-water",
+    srcs = ["solution.go"],
+    importpath = "github.com/colin-valentini/go/practice/problems/leetcode/array/trapping-rain-water",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "trapping-rain-water_test",
+    srcs = ["solution_test.go"],
+    embed = [":trapping-rain-water"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/practice/problems/leetcode/graph/clone-graph/BUILD.bazel
+++ b/practice/problems/leetcode/graph/clone-graph/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "clone-graph",
+    srcs = ["solution.go"],
+    importpath = "github.com/colin-valentini/go/practice/problems/leetcode/graph/clone-graph",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "clone-graph_test",
+    srcs = ["solution_test.go"],
+    embed = [":clone-graph"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/practice/problems/leetcode/graph/flood-fill/BUILD.bazel
+++ b/practice/problems/leetcode/graph/flood-fill/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "flood-fill",
+    srcs = ["solution.go"],
+    importpath = "github.com/colin-valentini/go/practice/problems/leetcode/graph/flood-fill",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "flood-fill_test",
+    srcs = ["solution_test.go"],
+    embed = [":flood-fill"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/practice/problems/leetcode/graph/max-area-of-island/BUILD.bazel
+++ b/practice/problems/leetcode/graph/max-area-of-island/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "max-area-of-island",
+    srcs = ["solution.go"],
+    importpath = "github.com/colin-valentini/go/practice/problems/leetcode/graph/max-area-of-island",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "max-area-of-island_test",
+    srcs = ["solution_test.go"],
+    embed = [":max-area-of-island"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/practice/problems/leetcode/graph/number-of-closed-islands/BUILD.bazel
+++ b/practice/problems/leetcode/graph/number-of-closed-islands/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "number-of-closed-islands",
+    srcs = ["solution.go"],
+    importpath = "github.com/colin-valentini/go/practice/problems/leetcode/graph/number-of-closed-islands",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "number-of-closed-islands_test",
+    srcs = ["solution_test.go"],
+    embed = [":number-of-closed-islands"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/practice/problems/leetcode/graph/number-of-enclaves/BUILD.bazel
+++ b/practice/problems/leetcode/graph/number-of-enclaves/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "number-of-enclaves",
+    srcs = ["solution.go"],
+    importpath = "github.com/colin-valentini/go/practice/problems/leetcode/graph/number-of-enclaves",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "number-of-enclaves_test",
+    srcs = ["soution_test.go"],
+    embed = [":number-of-enclaves"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/practice/problems/leetcode/graph/number-of-islands/BUILD.bazel
+++ b/practice/problems/leetcode/graph/number-of-islands/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "number-of-islands",
+    srcs = ["solution.go"],
+    importpath = "github.com/colin-valentini/go/practice/problems/leetcode/graph/number-of-islands",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "number-of-islands_test",
+    srcs = ["solution_test.go"],
+    embed = [":number-of-islands"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/practice/problems/leetcode/graph/surrounded-regions/BUILD.bazel
+++ b/practice/problems/leetcode/graph/surrounded-regions/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "surrounded-regions",
+    srcs = ["solution.go"],
+    importpath = "github.com/colin-valentini/go/practice/problems/leetcode/graph/surrounded-regions",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "surrounded-regions_test",
+    srcs = ["solution_test.go"],
+    embed = [":surrounded-regions"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/practice/problems/leetcode/palindrome/longest-palindromic-substring/BUILD.bazel
+++ b/practice/problems/leetcode/palindrome/longest-palindromic-substring/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "longest-palindromic-substring",
+    srcs = ["solution.go"],
+    importpath = "github.com/colin-valentini/go/practice/problems/leetcode/palindrome/longest-palindromic-substring",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "longest-palindromic-substring_test",
+    srcs = ["solution_test.go"],
+    embed = [":longest-palindromic-substring"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/practice/problems/leetcode/palindrome/palindrome-number/BUILD.bazel
+++ b/practice/problems/leetcode/palindrome/palindrome-number/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "palindrome-number",
+    srcs = ["solution.go"],
+    importpath = "github.com/colin-valentini/go/practice/problems/leetcode/palindrome/palindrome-number",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "palindrome-number_test",
+    srcs = ["solution_test.go"],
+    embed = [":palindrome-number"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/practice/problems/leetcode/string/find-words-that-can-be-formed-by-characters/BUILD.bazel
+++ b/practice/problems/leetcode/string/find-words-that-can-be-formed-by-characters/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "find-words-that-can-be-formed-by-characters",
+    srcs = ["solution.go"],
+    importpath = "github.com/colin-valentini/go/practice/problems/leetcode/string/find-words-that-can-be-formed-by-characters",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "find-words-that-can-be-formed-by-characters_test",
+    srcs = ["solution_test.go"],
+    embed = [":find-words-that-can-be-formed-by-characters"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/practice/problems/leetcode/string/string-to-integer-atoi/BUILD.bazel
+++ b/practice/problems/leetcode/string/string-to-integer-atoi/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "string-to-integer-atoi",
+    srcs = ["solution.go"],
+    importpath = "github.com/colin-valentini/go/practice/problems/leetcode/string/string-to-integer-atoi",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "string-to-integer-atoi_test",
+    srcs = ["solution_test.go"],
+    embed = [":string-to-integer-atoi"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)


### PR DESCRIPTION
Adds `bazel` build tooling for local development, but does not add it to the CI/CD pipeline (will address later). Trying to keep this limited to the things that would most benefit from being "bazel-ified" (i.e. build & test), and not including things that are not super straightforward to add (i.e. linting, vetting, formatting using bazel).

Note, this also adds a make target for running `golangci-lint` which is what the pipeline runs.